### PR TITLE
修正除数为0的bug

### DIFF
--- a/CalculateParams.py
+++ b/CalculateParams.py
@@ -25,7 +25,7 @@ def MACD(close_list):
 
 def MeanAndStd(num_list, p_list=0):
 	n = len(num_list)
-	if p_list==0 or len(p_list)==0:
+	if sum(p_list)==0 or len(p_list)==0:
 		p_list = [1.0/n] * n
 	else:
 		sum_p = sum(p_list)


### PR DESCRIPTION
修正极端情况下，没有交易量时，p_list=[0，...，0]，line30:``` p_list[i] = p_list[i]/sum_p```会出现sum_p为0的错误。